### PR TITLE
Sync up JS MediaStreamTrack state with iosrtc

### DIFF
--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -79,12 +79,13 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall) {
+			if (CordovaCall && this._sessionId) {
 				if (this._enabled === !value) {
 					!value
 						? CordovaCall.mute(this._sessionId, () => (this._enabled = false))
 						: CordovaCall.unmute(this._sessionId, () => (this._enabled = true));
 					this._enabled = !!value;
+					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 				}
 				return;
 			}

--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -85,8 +85,8 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 						? CordovaCall.mute(this._sessionId, () => (this._enabled = false))
 						: CordovaCall.unmute(this._sessionId, () => (this._enabled = true));
 					this._enabled = !!value;
-					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 				}
+				exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 				return;
 			}
 		}

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -32,11 +32,6 @@ class PluginMediaStreamTrack : NSObject {
 
 		self.kind = rtcMediaStreamTrack.kind
 		self.renders = [:]
-
-		// Ensure the track is enabled when first wrapped. The underlying
-		// RTCMediaStreamTrack may have been disabled by a previous stop() call
-		// (e.g. after hold teardown) — reset it so remote audio plays on unhold.
-		self.rtcMediaStreamTrack.isEnabled = true
 	}
 
 	deinit {

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -32,6 +32,11 @@ class PluginMediaStreamTrack : NSObject {
 
 		self.kind = rtcMediaStreamTrack.kind
 		self.renders = [:]
+
+		// Ensure the track is enabled when first wrapped. The underlying
+		// RTCMediaStreamTrack may have been disabled by a previous stop() call
+		// (e.g. after hold teardown) — reset it so remote audio plays on unhold.
+		self.rtcMediaStreamTrack.isEnabled = true
 	}
 
 	deinit {

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1206,12 +1206,13 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall) {
+			if (CordovaCall && this._sessionId) {
 				if (this._enabled === !value) {
 					!value
 						? CordovaCall.mute(this._sessionId, () => (this._enabled = false))
 						: CordovaCall.unmute(this._sessionId, () => (this._enabled = true));
 					this._enabled = !!value;
+					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 				}
 				return;
 			}

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1212,8 +1212,8 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 						? CordovaCall.mute(this._sessionId, () => (this._enabled = false))
 						: CordovaCall.unmute(this._sessionId, () => (this._enabled = true));
 					this._enabled = !!value;
-					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 				}
+				exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 				return;
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/iotum/facetalk/issues/12048

Bug: Running `MediaStreamTrack.enabled = true/false` in JS doesn't actually do anything since it's being returned early for CordovaCall.

Fix: Send the command to native to action on. CordovaCall.mute/unmute is only UI, it doesn't actually enable/disable the track itself