### PR TITLE
remove the callkit integration, don't emit to native iosrtc for disable

### DIFF
--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -79,14 +79,7 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall && this._sessionId) {
-				if (this._enabled === !value) {
-					!value
-						? CordovaCall.mute(this._sessionId, () => (this._enabled = false))
-						: CordovaCall.unmute(this._sessionId, () => (this._enabled = true));
-					this._enabled = !!value;
-				}
-				exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
+			if (CordovaCall && !value) {
 				return;
 			}
 		}

--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -77,10 +77,14 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 	set: function (value) {
 		debug('enabled = %s', !!value);
 
+		// Don't disable the track natively for Softphone, allow enabling to fix audio not enabled bug when unholding the app
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall && !value) {
-				return;
+			if (CordovaCall && this._sessionId) {
+				if (this._enabled === !value && !value) {
+					this._enabled = !!value;
+					return;
+				}
 			}
 		}
 

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1206,14 +1206,7 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall && this._sessionId) {
-				if (this._enabled === !value) {
-					!value
-						? CordovaCall.mute(this._sessionId, () => (this._enabled = false))
-						: CordovaCall.unmute(this._sessionId, () => (this._enabled = true));
-					this._enabled = !!value;
-				}
-				exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
+			if (CordovaCall && !value) {
 				return;
 			}
 		}

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1204,10 +1204,14 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 	set: function (value) {
 		debug('enabled = %s', !!value);
 
+		// Don't disable the track natively for Softphone, allow enabling to fix audio not enabled bug when unholding the app
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall && !value) {
-				return;
+			if (CordovaCall && this._sessionId) {
+				if (this._enabled === !value && !value) {
+					this._enabled = !!value;
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
Remove the call to native iosrtc if we're disabling the track.
This was causing all sorts of problems.
The native track enabling/disabling is causing Callkit to emit mute/unmute callbacks.

For softphone we want to keep the ability to tell native iosrtc to enable the track, due to a bug with the remote track not playing after unhold.

This isn't actually a significant change, since we used to discard all events for enable/disable from reaching iosrtc. Now we only discard `disable` because we want to be able to forcibly enable a track natively from JS.