### PR TITLE
cede audioSession and audio output to callkit

### DIFF
--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -80,11 +80,13 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 		// Don't disable the track natively for Softphone, allow enabling to fix audio not enabled bug when unholding the app
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall && this._sessionId) {
-				if (this._enabled === !value && !value) {
-					this._enabled = !!value;
-					return;
+			if (CordovaCall) {
+				this._enabled = !!value;
+				if (this._sync) {
+					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
+					this._sync = false;
 				}
+				return;
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-iosrtc",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "description": "Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs",
   "author": "Iñaki Baz Castillo (https://inakibaz.me)",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 		id="cordova-plugin-iosrtc"
-		version="12.1.0">
+		version="12.2.0">
 
 	<name>iosrtc</name>
 	<description>Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,14 +30,14 @@
 		</config-file>
 
 		<preference name="MANUAL_INIT_AUDIO_DEVICE" default="TRUE"/>
-		<preference name="USE_MANUAL_AUDIO" default="TRUE"/>
+		<preference name="CEDE_AUDIO_SESSION_TO_CALLKIT" default="TRUE"/>
 
 		<config-file target="*-Info.plist" parent="ManualInitAudioDevice">
 			<string>$MANUAL_INIT_AUDIO_DEVICE</string>
 		</config-file>
 
-		<config-file target="*-Info.plist" parent="UseManualAudio">
-			<string>$USE_MANUAL_AUDIO</string>
+		<config-file target="*-Info.plist" parent="CedeAudioSessionToCallKit">
+			<string>$CEDE_AUDIO_SESSION_TO_CALLKIT</string>
 		</config-file>
 
 		<config-file target="*-Info.plist" parent="UseManualLayoutRenderer">

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,10 +29,15 @@
 			</feature>
 		</config-file>
 
-		<preference name="MANUAL_INIT_AUDIO_DEVICE" default="FALSE"/>
+		<preference name="MANUAL_INIT_AUDIO_DEVICE" default="TRUE"/>
+		<preference name="USE_MANUAL_AUDIO" default="TRUE"/>
 
 		<config-file target="*-Info.plist" parent="ManualInitAudioDevice">
 			<string>$MANUAL_INIT_AUDIO_DEVICE</string>
+		</config-file>
+
+		<config-file target="*-Info.plist" parent="UseManualAudio">
+			<string>$USE_MANUAL_AUDIO</string>
 		</config-file>
 
 		<config-file target="*-Info.plist" parent="UseManualLayoutRenderer">

--- a/src/PluginRTCAudioController.swift
+++ b/src/PluginRTCAudioController.swift
@@ -13,7 +13,7 @@ import AVFoundation
 class PluginRTCAudioController {
 	static let instance = PluginRTCAudioController()
 	
-	// Have callkit manually manage the audio session, where iosrtc should not be messing with it at all
+	// Have CallKit manually manage the audio session, where iosrtc should not be messing with it at all
 	static private var useManualAudio: Bool = true
 
 	static private let inactiveAudioCategory: AVAudioSession.Category = .playback

--- a/src/PluginRTCAudioController.swift
+++ b/src/PluginRTCAudioController.swift
@@ -12,6 +12,9 @@ import AVFoundation
 
 class PluginRTCAudioController {
 	static let instance = PluginRTCAudioController()
+	
+	// Have callkit manually manage the audio session, where iosrtc should not be messing with it at all
+	static private var useManualAudio: Bool = true
 
 	static private let inactiveAudioCategory: AVAudioSession.Category = .playback
 	static private let inactiveCategoryOptions: AVAudioSession.CategoryOptions = []
@@ -40,6 +43,10 @@ class PluginRTCAudioController {
 	//
 
 	static func initAudioDevices() -> Void {
+		guard !useManualAudio else {
+			NSLog("PluginRTCAudioController#initAudioDevices() | skipped, useManualAudio is enabled")
+			return
+		}
 
 		PluginRTCAudioController.setCategory()
 
@@ -52,7 +59,10 @@ class PluginRTCAudioController {
 	}
 
 	static func setCategory() -> Void {
-		// Enable speaker
+		guard !useManualAudio else {
+			NSLog("PluginRTCAudioController#setCategory() | skipped, useManualAudio is enabled")
+			return
+		}
 		NSLog("PluginRTCAudioController#setCategory()")
 
 		do {
@@ -80,6 +90,11 @@ class PluginRTCAudioController {
 
 	// Setter function inserted by set specific audio device
 	static func restoreInputOutputAudioDevice() -> Void {
+		guard !useManualAudio else {
+			NSLog("PluginRTCAudioController#restoreInputOutputAudioDevice() | skipped, useManualAudio is enabled")
+			return
+		}
+
 		let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
 
 		do {
@@ -92,6 +107,10 @@ class PluginRTCAudioController {
 	}
 
 	static func setOutputSpeakerIfNeed(enabled: Bool) {
+		guard !useManualAudio else {
+			NSLog("PluginRTCAudioController#setOutputSpeakerIfNeed() | skipped, useManualAudio is enabled")
+			return
+		}
 
 		speakerEnabled = enabled
 
@@ -126,7 +145,10 @@ class PluginRTCAudioController {
 	}
 
 	static func selectAudioOutputSpeaker() {
-		// Enable speaker
+		guard !useManualAudio else {
+			NSLog("PluginRTCAudioController#selectAudioOutputSpeaker() | skipped, useManualAudio is enabled")
+			return
+		}
 		NSLog("PluginRTCAudioController#selectAudioOutputSpeaker()")
 
 		speakerEnabled = true;
@@ -142,7 +164,10 @@ class PluginRTCAudioController {
 	}
 
 	static func selectAudioOutputEarpiece() {
-		// Disable speaker, switched to default
+		guard !useManualAudio else {
+			NSLog("PluginRTCAudioController#selectAudioOutputEarpiece() | skipped, useManualAudio is enabled")
+			return
+		}
 		NSLog("PluginRTCAudioController#selectAudioOutputEarpiece()")
 
 		speakerEnabled = false;
@@ -158,8 +183,11 @@ class PluginRTCAudioController {
 	}
 
     static func setDefaultAudioOutput(isSpeaker: Bool) {
+			  guard !useManualAudio else {
+            NSLog("PluginRTCAudioController#setDefaultAudioOutput() | skipped, useManualAudio is enabled")
+            return
+        }
         NSLog("PluginRTCAudioController#setDefaultAudioOutput() | isSpeaker \(isSpeaker)")
-        
     	speakerEnabled = isSpeaker
 
         let audioConfiguration = RTCAudioSessionConfiguration()
@@ -183,22 +211,22 @@ class PluginRTCAudioController {
 	private var audioSendersCount = 0
 
 	init() {
-		// Always enable manual audio mode so WebRTC does not auto-start/stop the audio
-		// unit. The plugin activates and deactivates it internally via firstAudioSenderCreated
-		// and lastAudioSenderDestroyed, covering all call paths (addStream, addTrack, close, etc.)
-		RTCAudioSession.sharedInstance().useManualAudio = true
+		Self.useManualAudio = (Bundle.main.object(forInfoDictionaryKey: "UseManualAudio") as? String) != "FALSE"
+		RTCAudioSession.sharedInstance().useManualAudio = Self.useManualAudio
 
 		let shouldManualInit = Bundle.main.object(forInfoDictionaryKey: "ManualInitAudioDevice") as? String
 
-		if(shouldManualInit == "FALSE") {
+		if(shouldManualInit == "FALSE" && !Self.useManualAudio) {
 			PluginRTCAudioController.initAudioDevices()
 		}
 
-		NotificationCenter.default.addObserver(
-			self,
-			selector: #selector(self.audioRouteChangeListener(_:)),
-			name: AVAudioSession.routeChangeNotification,
-			object: nil)
+		if(!Self.useManualAudio) {
+			NotificationCenter.default.addObserver(
+				self,
+				selector: #selector(self.audioRouteChangeListener(_:)),
+				name: AVAudioSession.routeChangeNotification,
+				object: nil)
+		}
 	}
 
 	@objc dynamic fileprivate func audioRouteChangeListener(_ notification:Notification) {
@@ -216,9 +244,17 @@ class PluginRTCAudioController {
 	}
 
 	private func firstAudioSenderCreated() {
+		guard !Self.useManualAudio else {
+			NSLog("PluginRTCAudioController#firstAudioSenderCreated() | skipped, useManualAudio is enabled")
+			return
+		}
+
 		let rtcAudioSession = RTCAudioSession.sharedInstance()
 
 		rtcAudioSession.lockForConfiguration()
+		defer {
+			rtcAudioSession.unlockForConfiguration()
+		}
 
 		let defaultWebRTCConfiguration = RTCAudioSessionConfiguration()
 
@@ -233,22 +269,20 @@ class PluginRTCAudioController {
 
 		try? rtcAudioSession.setCategory(AVAudioSession.Category(rawValue: category), with: categoryOptions)
 		try? rtcAudioSession.setMode(AVAudioSession.Mode(rawValue: mode))
-
-		rtcAudioSession.unlockForConfiguration()
-
-		NSLog("PluginRTCAudioController#firstAudioSenderCreated() | activating audio session")
-		rtcAudioSession.audioSessionDidActivate(AVAudioSession.sharedInstance())
-		rtcAudioSession.isAudioEnabled = true
 	}
 
 	private func lastAudioSenderDestroyed() {
+		guard !Self.useManualAudio else {
+			NSLog("PluginRTCAudioController#lastAudioSenderDestroyed() | skipped, useManualAudio is enabled")
+			return
+		}
+
 		let rtcAudioSession = RTCAudioSession.sharedInstance()
 
-		NSLog("PluginRTCAudioController#lastAudioSenderDestroyed() | deactivating audio session")
-		rtcAudioSession.audioSessionDidDeactivate(AVAudioSession.sharedInstance())
-		rtcAudioSession.isAudioEnabled = false
-
 		rtcAudioSession.lockForConfiguration()
+		defer {
+			rtcAudioSession.unlockForConfiguration()
+		}
 
 		let category = Self.inactiveAudioCategory.rawValue
 		let mode = Self.audioModeDefault.rawValue
@@ -261,9 +295,6 @@ class PluginRTCAudioController {
 
 		try? rtcAudioSession.setMode(AVAudioSession.Mode(rawValue: mode))
 		try? rtcAudioSession.setCategory(AVAudioSession.Category(rawValue: category), with: categoryOptions)
-
-		rtcAudioSession.unlockForConfiguration()
-
 		try? AVAudioSession.sharedInstance().setActive(true)
 	}
 

--- a/src/PluginRTCAudioController.swift
+++ b/src/PluginRTCAudioController.swift
@@ -14,7 +14,7 @@ class PluginRTCAudioController {
 	static let instance = PluginRTCAudioController()
 	
 	// Have CallKit manually manage the audio session, where iosrtc should not be messing with it at all
-	static private var useManualAudio: Bool = true
+	static private var cedeAudioSessionToCallKit: Bool = true
 
 	static private let inactiveAudioCategory: AVAudioSession.Category = .playback
 	static private let inactiveCategoryOptions: AVAudioSession.CategoryOptions = []
@@ -43,8 +43,8 @@ class PluginRTCAudioController {
 	//
 
 	static func initAudioDevices() -> Void {
-		guard !useManualAudio else {
-			NSLog("PluginRTCAudioController#initAudioDevices() | skipped, useManualAudio is enabled")
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#initAudioDevices() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 
@@ -59,8 +59,8 @@ class PluginRTCAudioController {
 	}
 
 	static func setCategory() -> Void {
-		guard !useManualAudio else {
-			NSLog("PluginRTCAudioController#setCategory() | skipped, useManualAudio is enabled")
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#setCategory() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 		NSLog("PluginRTCAudioController#setCategory()")
@@ -90,8 +90,8 @@ class PluginRTCAudioController {
 
 	// Setter function inserted by set specific audio device
 	static func restoreInputOutputAudioDevice() -> Void {
-		guard !useManualAudio else {
-			NSLog("PluginRTCAudioController#restoreInputOutputAudioDevice() | skipped, useManualAudio is enabled")
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#restoreInputOutputAudioDevice() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 
@@ -107,8 +107,8 @@ class PluginRTCAudioController {
 	}
 
 	static func setOutputSpeakerIfNeed(enabled: Bool) {
-		guard !useManualAudio else {
-			NSLog("PluginRTCAudioController#setOutputSpeakerIfNeed() | skipped, useManualAudio is enabled")
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#setOutputSpeakerIfNeed() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 
@@ -145,8 +145,8 @@ class PluginRTCAudioController {
 	}
 
 	static func selectAudioOutputSpeaker() {
-		guard !useManualAudio else {
-			NSLog("PluginRTCAudioController#selectAudioOutputSpeaker() | skipped, useManualAudio is enabled")
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#selectAudioOutputSpeaker() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 		NSLog("PluginRTCAudioController#selectAudioOutputSpeaker()")
@@ -164,8 +164,8 @@ class PluginRTCAudioController {
 	}
 
 	static func selectAudioOutputEarpiece() {
-		guard !useManualAudio else {
-			NSLog("PluginRTCAudioController#selectAudioOutputEarpiece() | skipped, useManualAudio is enabled")
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#selectAudioOutputEarpiece() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 		NSLog("PluginRTCAudioController#selectAudioOutputEarpiece()")
@@ -182,25 +182,25 @@ class PluginRTCAudioController {
 		};
 	}
 
-    static func setDefaultAudioOutput(isSpeaker: Bool) {
-			  guard !useManualAudio else {
-            NSLog("PluginRTCAudioController#setDefaultAudioOutput() | skipped, useManualAudio is enabled")
-            return
-        }
-        NSLog("PluginRTCAudioController#setDefaultAudioOutput() | isSpeaker \(isSpeaker)")
-    	speakerEnabled = isSpeaker
+	static func setDefaultAudioOutput(isSpeaker: Bool) {
+		guard !cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#setDefaultAudioOutput() | skipped, cedeAudioSessionToCallKit is enabled")
+			return
+		}
+		NSLog("PluginRTCAudioController#setDefaultAudioOutput() | isSpeaker \(isSpeaker)")
+		speakerEnabled = isSpeaker
 
-        let audioConfiguration = RTCAudioSessionConfiguration()
-        audioConfiguration.category = PluginRTCAudioController.audioCategory.rawValue;
-        audioConfiguration.categoryOptions = PluginRTCAudioController.audioCategoryOptions
-        audioConfiguration.mode = PluginRTCAudioController.audioMode.rawValue
+		let audioConfiguration = RTCAudioSessionConfiguration()
+		audioConfiguration.category = PluginRTCAudioController.audioCategory.rawValue;
+		audioConfiguration.categoryOptions = PluginRTCAudioController.audioCategoryOptions
+		audioConfiguration.mode = PluginRTCAudioController.audioMode.rawValue
 
-        if (speakerEnabled) {
-            audioConfiguration.categoryOptions.insert(AVAudioSession.CategoryOptions.defaultToSpeaker)
-        }
+		if (speakerEnabled) {
+			audioConfiguration.categoryOptions.insert(AVAudioSession.CategoryOptions.defaultToSpeaker)
+		}
 
-        RTCAudioSessionConfiguration.setWebRTC(audioConfiguration)
-    }
+		RTCAudioSessionConfiguration.setWebRTC(audioConfiguration)
+	}
 
 	//
 	// Audio Output
@@ -211,16 +211,16 @@ class PluginRTCAudioController {
 	private var audioSendersCount = 0
 
 	init() {
-		Self.useManualAudio = (Bundle.main.object(forInfoDictionaryKey: "UseManualAudio") as? String) != "FALSE"
-		RTCAudioSession.sharedInstance().useManualAudio = Self.useManualAudio
+		Self.cedeAudioSessionToCallKit = (Bundle.main.object(forInfoDictionaryKey: "CedeAudioSessionToCallKit") as? String) != "FALSE"
+		RTCAudioSession.sharedInstance().useManualAudio = Self.cedeAudioSessionToCallKit
 
 		let shouldManualInit = Bundle.main.object(forInfoDictionaryKey: "ManualInitAudioDevice") as? String
 
-		if(shouldManualInit == "FALSE" && !Self.useManualAudio) {
+		if(shouldManualInit == "FALSE" && !Self.cedeAudioSessionToCallKit) {
 			PluginRTCAudioController.initAudioDevices()
 		}
 
-		if(!Self.useManualAudio) {
+		if(!Self.cedeAudioSessionToCallKit) {
 			NotificationCenter.default.addObserver(
 				self,
 				selector: #selector(self.audioRouteChangeListener(_:)),
@@ -244,8 +244,8 @@ class PluginRTCAudioController {
 	}
 
 	private func firstAudioSenderCreated() {
-		guard !Self.useManualAudio else {
-			NSLog("PluginRTCAudioController#firstAudioSenderCreated() | skipped, useManualAudio is enabled")
+		guard !Self.cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#firstAudioSenderCreated() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 
@@ -272,8 +272,8 @@ class PluginRTCAudioController {
 	}
 
 	private func lastAudioSenderDestroyed() {
-		guard !Self.useManualAudio else {
-			NSLog("PluginRTCAudioController#lastAudioSenderDestroyed() | skipped, useManualAudio is enabled")
+		guard !Self.cedeAudioSessionToCallKit else {
+			NSLog("PluginRTCAudioController#lastAudioSenderDestroyed() | skipped, cedeAudioSessionToCallKit is enabled")
 			return
 		}
 

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1207,11 +1207,13 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 		// Don't disable the track natively for Softphone, allow enabling to fix audio not enabled bug when unholding the app
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall && this._sessionId) {
-				if (this._enabled === !value && !value) {
-					this._enabled = !!value;
-					return;
+			if (CordovaCall) {
+				this._enabled = !!value;
+				if (this._sync) {
+					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
+					this._sync = false;
 				}
+				return;
 			}
 		}
 


### PR DESCRIPTION
Add guard statements so iosrtc can't touch the AudioSession or Audio Output as Callkit is solely responsible for it.

Fix the integration with CordovaCall, always update the iosrtc JS and only emit to native iosrtc when we force a sync.