### PR TITLE
Disable WebRTC audio processing features

### DIFF
--- a/src/PluginGetUserMedia.swift
+++ b/src/PluginGetUserMedia.swift
@@ -152,7 +152,19 @@ class PluginGetUserMedia {
 				}
 			}
 
-			rtcAudioTrack = self.rtcPeerConnectionFactory.audioTrack(withTrackId: UUID().uuidString)
+			// Disable WebRTC software AEC/AGC/NS to prevent double-processing on top of the iOS
+			// hardware AEC that is active via AVAudioSessionModeVoiceChat/VideoChat (VPIO audio unit).
+			let noProcessingConstraints = RTCMediaConstraints(
+				mandatoryConstraints: nil,
+				optionalConstraints: [
+					"googEchoCancellation": "false",
+					"googNoiseSuppression": "false",
+					"googAutoGainControl": "false",
+					"googHighpassFilter": "false"
+				]
+			)
+			let audioSource = self.rtcPeerConnectionFactory.audioSource(with: noProcessingConstraints)
+			rtcAudioTrack = self.rtcPeerConnectionFactory.audioTrack(with: audioSource, trackId: UUID().uuidString)
 			rtcMediaStream.addAudioTrack(rtcAudioTrack!)
 
 			if (audioDeviceId != nil) {


### PR DESCRIPTION
### Disable WebRTC software AEC/AGC/NS (`audioRequested` block)

**Before:**
```swift
let audioSource = self.rtcPeerConnectionFactory.audioSource(withConstraints: nil)
```

**After:**
```swift
let noProcessingConstraints = RTCMediaConstraints(
    mandatoryConstraints: nil,
    optionalConstraints: [
        "googEchoCancellation": "false",
        "googNoiseSuppression": "false",
        "googAutoGainControl": "false",
        "googHighpassFilter": "false"
    ]
)
let audioSource = self.rtcPeerConnectionFactory.audioSource(with: noProcessingConstraints)
```

**Rationale:** `AVAudioSessionModeVoiceChat`/`VideoChat` (set in CordovaCall.m) activates iOS's VPIO hardware unit, which provides hardware AEC, AGC, and NS. Without this change, WebRTC's software processing stack runs *on top of* the already hardware-processed audio, causing double-processing artifacts — audible as echo, distortion, or gain pumping. The `goog*` optional constraints are the supported API surface for disabling these in this WebRTC build; `bypassVoiceProcessing` is not exposed in the public headers used here.
