### PR TITLE
Allow modifiying useManualAudio and cedeAudioSessionToCallKit in runtime

### DIFF
--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -77,12 +77,17 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 	set: function (value) {
 		debug('enabled = %s', !!value);
 
-		// Don't disable the track natively for Softphone, allow enabling to fix audio not enabled bug when unholding the app
+		// Don't disable the track on mute/unmute
+		// Affects MST.canSendDTMF while muted, should be true
+		// TODO: Refactor this so we only filter during an ongoing softphone/video call
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
 			if (CordovaCall) {
-				this._enabled = !!value;
+				// Allow forcing a sync
+				// When held, remote native MST is disabled due to a=inactive without syncing with JS MST, allow facetalk to force MST._enabled = true
+				// TODO: Remove this hack, find out why the remote track is disabled and/or not synced
 				if (this._sync) {
+					this._enabled = !!value;
 					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 					this._sync = false;
 				}

--- a/js/iosrtc.js
+++ b/js/iosrtc.js
@@ -65,6 +65,11 @@ module.exports = {
 	// Expose a function to initAudioDevices if needed, sets the audio session active
 	initAudioDevices: initAudioDevices,
 
+	// Override the CallKit audio session cede flag at runtime.
+	// Pass false to have iosrtc manage the AVAudioSession (fallback when
+	// CallKit fails to activate the session, e.g. on permission denial).
+	setCedeAudioSessionToCallKit: setCedeAudioSessionToCallKit,
+
 	// Expose a function to pollute window and naigator namespaces.
 	registerGlobals: registerGlobals,
 
@@ -137,6 +142,12 @@ function initAudioDevices() {
 	debug('initAudioDevices()');
 
 	exec(null, null, 'iosrtcPlugin', 'initAudioDevices', []);
+}
+
+function setCedeAudioSessionToCallKit(cede) {
+	debug('setCedeAudioSessionToCallKit() | [cede:%s]', cede);
+
+	exec(null, null, 'iosrtcPlugin', 'setCedeAudioSessionToCallKit', [!!cede]);
 }
 
 function callbackifyMethod(originalMethod) {

--- a/src/PluginRTCAudioController.swift
+++ b/src/PluginRTCAudioController.swift
@@ -32,6 +32,16 @@ class PluginRTCAudioController {
 			} catch {
 				NSLog("PluginRTCAudioController#setCedeAudioSessionToCallKit() | setActive ERROR \(error)")
 			}
+			NotificationCenter.default.addObserver(
+				instance,
+				selector: #selector(instance.audioRouteChangeListener(_:)),
+				name: AVAudioSession.routeChangeNotification,
+				object: nil)
+		} else {
+			NotificationCenter.default.removeObserver(
+				instance,
+				name: AVAudioSession.routeChangeNotification,
+				object: nil)
 		}
 	}
 

--- a/src/PluginRTCAudioController.swift
+++ b/src/PluginRTCAudioController.swift
@@ -16,6 +16,25 @@ class PluginRTCAudioController {
 	// Have CallKit manually manage the audio session, where iosrtc should not be messing with it at all
 	static private var cedeAudioSessionToCallKit: Bool = true
 
+	/// Allows JS to override the CallKit cede flag at runtime.
+	/// Pass `false` to have iosrtc manage the AVAudioSession itself
+	/// (useful as a fallback when CallKit fails to activate the session,
+	/// e.g. when microphone/camera permissions are denied).
+	static func setCedeAudioSessionToCallKit(_ cede: Bool) -> Void {
+		NSLog("PluginRTCAudioController#setCedeAudioSessionToCallKit() | cede: \(cede)")
+		cedeAudioSessionToCallKit = cede
+		RTCAudioSession.sharedInstance().useManualAudio = cede
+		if !cede {
+			// iosrtc now owns the session – apply category and activate.
+			setCategory()
+			do {
+				try AVAudioSession.sharedInstance().setActive(true)
+			} catch {
+				NSLog("PluginRTCAudioController#setCedeAudioSessionToCallKit() | setActive ERROR \(error)")
+			}
+		}
+	}
+
 	static private let inactiveAudioCategory: AVAudioSession.Category = .playback
 	static private let inactiveCategoryOptions: AVAudioSession.CategoryOptions = []
 

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1374,6 +1374,12 @@ class iosrtcPlugin : CDVPlugin {
         PluginRTCAudioController.setDefaultAudioOutput(isSpeaker: isSpeaker)
 	}
 
+	@objc(setCedeAudioSessionToCallKit:) func setCedeAudioSessionToCallKit(_ command: CDVInvokedUrlCommand) {
+		NSLog("iosrtcPlugin#setCedeAudioSessionToCallKit()")
+		let cede: Bool = CBool(command.arguments[0] as! Bool)
+		PluginRTCAudioController.setCedeAudioSessionToCallKit(cede)
+	}
+
 	@objc(dump:) func dump(_ command: CDVInvokedUrlCommand) {
 		NSLog("iosrtcPlugin#dump()")
 

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1204,12 +1204,17 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 	set: function (value) {
 		debug('enabled = %s', !!value);
 
-		// Don't disable the track natively for Softphone, allow enabling to fix audio not enabled bug when unholding the app
+		// Don't disable the track on mute/unmute
+		// Affects MST.canSendDTMF while muted, should be true
+		// TODO: Refactor this so we only filter during an ongoing softphone/video call
 		if (this.kind === 'audio') {
 			var CordovaCall = window.cordova.plugins.CordovaCall;
 			if (CordovaCall) {
-				this._enabled = !!value;
+				// Allow forcing a sync
+				// When held, remote native MST is disabled due to a=inactive without syncing with JS MST, allow facetalk to force MST._enabled = true
+				// TODO: Remove this hack, find out why the remote track is disabled and/or not synced
 				if (this._sync) {
+					this._enabled = !!value;
 					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 					this._sync = false;
 				}

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -3931,6 +3931,11 @@ module.exports = {
 	// Expose a function to initAudioDevices if needed, sets the audio session active
 	initAudioDevices: initAudioDevices,
 
+	// Override the CallKit audio session cede flag at runtime.
+	// Pass false to have iosrtc manage the AVAudioSession (fallback when
+	// CallKit fails to activate the session, e.g. on permission denial).
+	setCedeAudioSessionToCallKit: setCedeAudioSessionToCallKit,
+
 	// Expose a function to pollute window and naigator namespaces.
 	registerGlobals: registerGlobals,
 
@@ -4003,6 +4008,12 @@ function initAudioDevices() {
 	debug('initAudioDevices()');
 
 	exec(null, null, 'iosrtcPlugin', 'initAudioDevices', []);
+}
+
+function setCedeAudioSessionToCallKit(cede) {
+	debug('setCedeAudioSessionToCallKit() | [cede:%s]', cede);
+
+	exec(null, null, 'iosrtcPlugin', 'setCedeAudioSessionToCallKit', [!!cede]);
 }
 
 function callbackifyMethod(originalMethod) {


### PR DESCRIPTION
Bug: When joining a video call without mic/camera permissions, the app crashes.

Cause: `CordovaCall.sendCall` is not called so `setupAudioSession` wasn't run. WebRTC doesn't set up the audio session either since it's `useManualAudio` and `cedeAudioSessionToCallKit`. The app crashed when it tried to play audio when no AudioSessions are configured and active.

Fix: Add a fallback to be called from JS to toggle `useManualAudio` and `cedeAudioSessionToCallKit` at runtime.

Requires: https://github.com/iotum/facetalk/pull/12624
