### PR TITLE
remove the hack due to canInsertDTMF returning false when the track.enabled = false

### DIFF
--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -77,24 +77,6 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 	set: function (value) {
 		debug('enabled = %s', !!value);
 
-		// Don't disable the track on mute/unmute
-		// Affects MST.canSendDTMF while muted, should be true
-		// TODO: Refactor this so we only filter during an ongoing softphone/video call
-		if (this.kind === 'audio') {
-			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall) {
-				// Allow forcing a sync
-				// When held, remote native MST is disabled due to a=inactive without syncing with JS MST, allow facetalk to force MST._enabled = true
-				// TODO: Remove this hack, find out why the remote track is disabled and/or not synced
-				if (this._sync) {
-					this._enabled = !!value;
-					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
-					this._sync = false;
-				}
-				return;
-			}
-		}
-
 		this._enabled = !!value;
 		exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 	}

--- a/js/RTCDTMFSender.js
+++ b/js/RTCDTMFSender.js
@@ -49,8 +49,9 @@ RTCDTMFSender.prototype.constructor = RTCDTMFSender;
 
 Object.defineProperty(RTCDTMFSender.prototype, 'canInsertDTMF', {
 	get: function () {
-		// TODO: check if it's muted or stopped?
-		return this._track && this._track.kind === 'audio' && this._track.enabled;
+		return !!this._track &&
+			this._track.kind === 'audio' &&
+			this._track.readyState === 'live';
 	}
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-iosrtc",
-  "version": "12.0.0",
+  "version": "12.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-iosrtc",
-      "version": "12.0.0",
+      "version": "12.3.2",
       "engines": [
         {
           "name": "cordova-ios",
@@ -137,6 +137,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
       "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2237,6 +2238,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
       "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.1",
@@ -4014,6 +4016,7 @@
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.4.tgz",
       "integrity": "sha512-HO3bosL84b2qWqI0q+kpT/OpRJwo0R4ivgmxaO848+bo10rc50SkPnrtwSFXttW0ym4np8jbJvLwk5NziB7jIw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
@@ -5269,6 +5272,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -7250,7 +7254,8 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
       "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.1",
@@ -9052,6 +9057,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
       "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.1",
@@ -10492,6 +10498,7 @@
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.4.tgz",
       "integrity": "sha512-HO3bosL84b2qWqI0q+kpT/OpRJwo0R4ivgmxaO848+bo10rc50SkPnrtwSFXttW0ym4np8jbJvLwk5NziB7jIw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
@@ -11501,7 +11508,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-iosrtc",
-  "version": "12.2.0",
+  "version": "12.3.2",
   "description": "Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs",
   "author": "Iñaki Baz Castillo (https://inakibaz.me)",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 		id="cordova-plugin-iosrtc"
-		version="12.2.0">
+		version="12.3.2">
 
 	<name>iosrtc</name>
 	<description>Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs</description>

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1,5 +1,5 @@
 /*
- * cordova-plugin-iosrtc v11.3.0
+ * cordova-plugin-iosrtc v12.3.2
  * Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs
  * Copyright 2015-2017 eFace2Face, Inc. (https://eface2face.com)
  * Copyright 2015-2019 BasqueVoIPMafia (https://github.com/BasqueVoIPMafia)

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1204,24 +1204,6 @@ Object.defineProperty(MediaStreamTrack.prototype, 'enabled', {
 	set: function (value) {
 		debug('enabled = %s', !!value);
 
-		// Don't disable the track on mute/unmute
-		// Affects MST.canSendDTMF while muted, should be true
-		// TODO: Refactor this so we only filter during an ongoing softphone/video call
-		if (this.kind === 'audio') {
-			var CordovaCall = window.cordova.plugins.CordovaCall;
-			if (CordovaCall) {
-				// Allow forcing a sync
-				// When held, remote native MST is disabled due to a=inactive without syncing with JS MST, allow facetalk to force MST._enabled = true
-				// TODO: Remove this hack, find out why the remote track is disabled and/or not synced
-				if (this._sync) {
-					this._enabled = !!value;
-					exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
-					this._sync = false;
-				}
-				return;
-			}
-		}
-
 		this._enabled = !!value;
 		exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_setEnabled', [this.id, this._enabled]);
 	}
@@ -1398,8 +1380,9 @@ RTCDTMFSender.prototype.constructor = RTCDTMFSender;
 
 Object.defineProperty(RTCDTMFSender.prototype, 'canInsertDTMF', {
 	get: function () {
-		// TODO: check if it's muted or stopped?
-		return this._track && this._track.kind === 'audio' && this._track.enabled;
+		return !!this._track &&
+			this._track.kind === 'audio' &&
+			this._track.readyState === 'live';
 	}
 });
 


### PR DESCRIPTION
This hack stopped us from sending `track.enabled = true/false` to native iosrtc, since `track.enabled = false` was causing `canInsertDTMF = false`.

Instead we should fix `canInsertDTMF` so it doesn't depend on `track.enabled`. The native implementation in libwebrtc appear to support the spec.
<img width="1200" height="1275" alt="image" src="https://github.com/user-attachments/assets/43246f8c-4a9b-4a1a-8608-ca8c3bc8f53a" />